### PR TITLE
Fix ClientsTable class name

### DIFF
--- a/app/Livewire/ClientsTable.php
+++ b/app/Livewire/ClientsTable.php
@@ -6,7 +6,7 @@ use App\Models\Client;
 use Illuminate\View\View;
 use Livewire\Component;
 
-class ClientSTable extends Component
+class ClientsTable extends Component
 {
     public string $search = '';
 


### PR DESCRIPTION
## Summary
- correct Livewire clients table class name

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683f7c0efbe88327a17da4067fc93509